### PR TITLE
Add remove-readonly argument

### DIFF
--- a/NStrip/AssemblyStripper.cs
+++ b/NStrip/AssemblyStripper.cs
@@ -101,7 +101,7 @@ namespace NStrip
 				assembly.MainModule.Resources.Clear();
 		}
 
-		public static void MakePublic(AssemblyDefinition assembly, IList<string> typeNameBlacklist, bool includeCompilerGenerated, bool excludeCgEvents)
+		public static void MakePublic(AssemblyDefinition assembly, IList<string> typeNameBlacklist, bool includeCompilerGenerated, bool excludeCgEvents, bool removeReadOnly)
 		{
 			bool checkCompilerGeneratedAttribute(IMemberDefinition member)
 			{
@@ -144,6 +144,9 @@ namespace NStrip
 					}
 
 					field.IsPublic = true;
+
+					if (removeReadOnly)
+						field.IsInitOnly = false;
 				}
 			}
 		}

--- a/NStrip/Program.cs
+++ b/NStrip/Program.cs
@@ -95,7 +95,7 @@ namespace NStrip
 				AssemblyStripper.StripAssembly(assemblyDefinition, arguments.StripType, arguments.KeepResources);
 
 			if (arguments.Public)
-				AssemblyStripper.MakePublic(assemblyDefinition, arguments.Blacklist, arguments.IncludeCompilerGenerated, arguments.ExcludeCompilerGeneratedEvents);
+				AssemblyStripper.MakePublic(assemblyDefinition, arguments.Blacklist, arguments.IncludeCompilerGenerated, arguments.ExcludeCompilerGeneratedEvents, arguments.RemoveReadOnlyAttribute);
 
 			// We write to a memory stream first to ensure that Mono.Cecil doesn't have any errors when producing the assembly.
 			// Otherwise, if we're overwriting the same assembly and it fails, it will overwrite with a 0 byte file
@@ -154,6 +154,9 @@ namespace NStrip
 
             [CommandDefinition("cg-exclude-events", Description = "To be used in conjunction with -cg. Will not publicize fields that are used to back auto-generated events.", Order = -1)]
             public bool ExcludeCompilerGeneratedEvents { get; set; }
+
+			[CommandDefinition("remove-readonly", Description = "Remove the readonly attribute from fields. Only works with the mono runtime.", Order = -1)]
+			public bool RemoveReadOnlyAttribute { get; set; }
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The general usage of NStrip is `NStrip [options] <input> (<output>)`. Input and 
   - `OnlyRet`: Only adds a ret opcode. Slightly smaller than ValueRet but may not be runtime-safe.
   - `EmptyBody`: No opcodes in body. Slightly smaller again but is not runtime-safe.
   - `Extern`: Marks all methods as extern, and removes their bodies. Smallest size, but not runtime-safe and might not be compile-time safe.
+- `-remove-readonly` removes the readonly attribute from fields. Only works with the mono runtime.
 
 ## Credits
 Uses NArgs from https://github.com/bbepis/NArgs


### PR DESCRIPTION
unlike net core, mono doesnt actually check if the field being assigned outside ctor is readonly (initonly) or not