### PR TITLE
Add "unity" argument

### DIFF
--- a/NStrip/AssemblyStripper.cs
+++ b/NStrip/AssemblyStripper.cs
@@ -114,7 +114,10 @@ namespace NStrip
 			{
 				var scope = assembly.MainModule.AssemblyReferences.OrderByDescending(a => a.Version).FirstOrDefault(a => a.Name == "mscorlib");
 				var attributeType = new TypeReference("System", "NonSerializedAttribute", assembly.MainModule, scope);
-				nonSerialized = new MethodReference(".ctor", assembly.MainModule.TypeSystem.Void, attributeType);
+				nonSerialized = new MethodReference(".ctor", assembly.MainModule.TypeSystem.Void, attributeType)
+				{
+					HasThis = true,
+				};
 			}
 
 			foreach (var type in GetAllTypeDefinitions(assembly))

--- a/NStrip/AssemblyStripper.cs
+++ b/NStrip/AssemblyStripper.cs
@@ -101,12 +101,20 @@ namespace NStrip
 				assembly.MainModule.Resources.Clear();
 		}
 
-		public static void MakePublic(AssemblyDefinition assembly, IList<string> typeNameBlacklist, bool includeCompilerGenerated, bool excludeCgEvents)
+		public static void MakePublic(AssemblyDefinition assembly, IList<string> typeNameBlacklist, bool includeCompilerGenerated, bool excludeCgEvents, bool unity)
 		{
 			bool checkCompilerGeneratedAttribute(IMemberDefinition member)
 			{
 				return member.CustomAttributes.Any(x =>
 					x.AttributeType.FullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
+			}
+
+			MethodReference nonSerialized = null;
+			if (unity)
+			{
+				var scope = assembly.MainModule.AssemblyReferences.OrderByDescending(a => a.Version).FirstOrDefault(a => a.Name == "mscorlib");
+				var attributeType = new TypeReference("System", "NonSerializedAttribute", assembly.MainModule, scope);
+				nonSerialized = new MethodReference(".ctor", assembly.MainModule.TypeSystem.Void, attributeType);
 			}
 
 			foreach (var type in GetAllTypeDefinitions(assembly))
@@ -141,6 +149,12 @@ namespace NStrip
 					{
 						if (type.Events.Any(x => x.Name == field.Name))
 							continue;
+					}
+
+					if (nonSerialized != null && !field.IsPublic && !field.CustomAttributes.Any(a => a.AttributeType.FullName == "UnityEngine.SerializeField"))
+					{
+						field.IsNotSerialized = true;
+						field.CustomAttributes.Add(new CustomAttribute(nonSerialized));
 					}
 
 					field.IsPublic = true;

--- a/NStrip/Program.cs
+++ b/NStrip/Program.cs
@@ -95,7 +95,7 @@ namespace NStrip
 				AssemblyStripper.StripAssembly(assemblyDefinition, arguments.StripType, arguments.KeepResources);
 
 			if (arguments.Public)
-				AssemblyStripper.MakePublic(assemblyDefinition, arguments.Blacklist, arguments.IncludeCompilerGenerated, arguments.ExcludeCompilerGeneratedEvents);
+				AssemblyStripper.MakePublic(assemblyDefinition, arguments.Blacklist, arguments.IncludeCompilerGenerated, arguments.ExcludeCompilerGeneratedEvents, arguments.Unity);
 
 			// We write to a memory stream first to ensure that Mono.Cecil doesn't have any errors when producing the assembly.
 			// Otherwise, if we're overwriting the same assembly and it fails, it will overwrite with a 0 byte file
@@ -154,6 +154,9 @@ namespace NStrip
 
             [CommandDefinition("cg-exclude-events", Description = "To be used in conjunction with -cg. Will not publicize fields that are used to back auto-generated events.", Order = -1)]
             public bool ExcludeCompilerGeneratedEvents { get; set; }
+
+			[CommandDefinition("u", "unity", Description = "In case you want publicized assembly for use inside Unity editor")]
+			public bool Unity { get; set; }
 		}
 	}
 }


### PR DESCRIPTION
When you use publicized assembly in Unity editor you don't want to see all public fields in your components and you don't want them to be serialized.